### PR TITLE
Fix for unregisterAll() Silent Failure

### DIFF
--- a/ib/opt/dispatcher.py
+++ b/ib/opt/dispatcher.py
@@ -141,4 +141,4 @@ class Dispatcher(object):
         @param listener callable to no longer receive messages
         @return True if disassociated with one or more handler; otherwise False
         """
-        return self.unregister(listener, *self.messageTypes.values())
+        return self.unregister(listener, *[maybeName(i) for v in list(self.messageTypes.values()) for i in v])


### PR DESCRIPTION
Per https://github.com/blampe/IbPy/issues/14, unregisterAll() silently fails. The problem is that messageType strings must be passed to self.unregister() as the 2nd+ argument in order for the unregistering process to work properly, but what's being passed in as the 2nd+ argument is *self.messageTypes.values(), which evaluates to 1-tuples and 2-tuples of the Message objects themselves. This causes unregisterAll() to fail silently. The fix passes in the messageType strings unregisterAll() needs to unregister a callback.